### PR TITLE
fix: correct occured->occurred typo in critical exception message

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ async def main():
         )
 
     except Exception as e:
-        print(f"Critical exception occured: {e}")
+        print(f"Critical exception occurred: {e}")
         # TODO: Add shutdown sequence here
         raise e
 


### PR DESCRIPTION
## Summary
Fix typo `occured` → `occurred` in the critical exception handler in `main.py` (line 22).

## Change
```diff
-        print(f"Critical exception occured: {e}")
+        print(f"Critical exception occurred: {e}")
```

## Why
This error message is displayed to users when a critical exception occurs during startup. Correcting the spelling improves readability during debugging.

## Testing
- Syntax verified (Python 3 compatible)
- Only 1 file changed, 1 line modified
- Matches existing code style